### PR TITLE
Adding MIT license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "Material Design"
   ],
   "author": "Dimitry Ivanov <2@ivanoff.org.ua> # curl -A cv ivanoff.org.ua",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ivanoff/react-native-ico-material-design/issues"
   },


### PR DESCRIPTION
Per https://github.com/ivanoff/react-svg-main/issues/4 I'm guessing this repository is MIT too?

I thought I'd ask via a PR rather than an issue to save you time :)