### PR TITLE
fix(type): type not defined for iconColors property

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -426,7 +426,7 @@ declare module 'react-native-ico-material-design' {
       'write-email-envelope-button' |
       'youtube-logo';
 
-    type iconColors = ;
+    type iconColors = string;
 
     type backgroundType = 'circle' | 'rect' | 'button';
 


### PR DESCRIPTION
Error on building project using typescript: 

node_modules/react-native-ico-material-design/typings.d.ts:429:23 - error TS1110: Type expected.

Fixes the error